### PR TITLE
feat: add support for custom config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Gaia stores its configuration in `~/.config/gaia/config.yaml`. The following set
 - `shell`: Shell command generation
 - `code`: Code generation without descriptions
 
+### Use an alternative yaml configuration file
+
+```bash
+gaia --config /path/to/custom/config.yaml ask "Hello!"
+# or
+GAIA_CONFIG=/path/to/custom/config.yaml gaia ask "Hello!"
+```
+
 ## Usage
 
 ### Basic Commands
@@ -62,6 +70,7 @@ gaia chat
 gaia config set model llama2
 gaia config set host 127.0.0.1
 gaia config set port 8080
+gaia config create
 
 # View current configuration
 gaia config list

--- a/main.go
+++ b/main.go
@@ -3,21 +3,13 @@ package main
 import (
 	"fmt"
 	"gaia/commands"
-	"gaia/config"
 	"os"
 )
 
 var ()
 
 func main() {
-	err := config.InitConfig()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	err = commands.Execute()
-	if err != nil {
+	if err := commands.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This commit introduces support for specifying an alternative configuration file through a new `--config` (or `-c`) CLI flag and the `GAIA_CONFIG`environment variable. If neither is provided, Gaia defaults to `~/.config/gaia/config.yaml`

This ensures a more flexible and non-intrusive configuration handling while maintaining backward compatibility with existing defaults.