### PR TITLE
fix(api): restore dynamic role template resolution with env and OS data

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -204,13 +206,28 @@ func pullModel() error {
 
 // Send a message to the API
 func sendMessage(msg string) error {
+	systemRole := viper.GetString("systemrole")
+	if systemRole == "" {
+		systemRole = viper.GetString("role")
+	}
+	if systemRole == "" {
+		systemRole = "default"
+	}
+
+	roleTemplate := viper.GetString(fmt.Sprintf("roles.%s", systemRole))
+
+	systemContent := ""
+	if roleTemplate != "" {
+		systemContent = fmt.Sprintf(roleTemplate, os.Getenv("SHELL"), runtime.GOOS)
+	}
+
 	// Prepare messages with history
 	messages := make([]Message, 0)
 
 	// Add system message
 	messages = append(messages, Message{
 		Role:    "system",
-		Content: "System message",
+		Content: systemContent,
 	})
 
 	// Add chat history


### PR DESCRIPTION
This patch reinstates functionality removed during a previous refactoring. Role templates (including the system role) are once again correctly loaded from configuration (`roles.*`) and selected based on the configured role (`systemrole` with fallbacks).

The message content is now generated dynamically by applying the role template and injecting the current shell environment variable and OS information (`$SHELL`, runtime.GOOS), replacing the static placeholder introduced by the regression.