### PR TITLE
fix: Remove Debug Log Output from OpenAI Chat Completion Request

### DIFF
--- a/api/openai_transport.go
+++ b/api/openai_transport.go
@@ -143,9 +143,6 @@ func (rt *openaiRoundTripper) handleChat(req *http.Request) (*http.Response, err
 		return nil, fmt.Errorf("marshal OpenAI payload: %w", err)
 	}
 
-	fmt.Printf("Calling OpenAI Chat Completions with model %s\n", modelName)
-	fmt.Printf("Payload: %s\n", string(payloadBytes))
-
 	openaiReq, err := http.NewRequest(
 		http.MethodPost,
 		"https://api.openai.com/v1/chat/completions",


### PR DESCRIPTION
This change removes debug logging code associated with the OpenAI Chat Completion requests. The logging of model names and payload data has been removed for cleaner code, potentially improving performance due to reduced output during runtime.