### PR TITLE
ci: Add condition to run release job only on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - run: go test -v .
   release:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This pull request introduces a small change to the CI workflow configuration. The `release` job will now only run when changes are pushed to the `main` branch, helping to prevent unintended releases from other branches.