### PR TITLE
fix(goreleaser): Update brew name to include version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
       - -X gaia/commands.commitSHA={{.FullCommit}}
       - -X gaia/commands.buildDate={{.Date}}
 brews:
-  - name: "gaia"
+  - name: "gaia@{{ .Version }}"
     homepage: "https://github.com/vonglasow/gaia"
     description: "Cli tool to ask local LLM with ollama"
     license: "GPL3"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
       - -X gaia/commands.commitSHA={{.FullCommit}}
       - -X gaia/commands.buildDate={{.Date}}
 brews:
-  - name: "gaia@{{ .Version }}"
+  - name: "gaia@{{ .Major }}.{{ .Minor }}"
     homepage: "https://github.com/vonglasow/gaia"
     description: "Cli tool to ask local LLM with ollama"
     license: "GPL3"


### PR DESCRIPTION
This pull request makes a small update to the Homebrew formula configuration in `.goreleaser.yaml` to include the version number in the formula name. This helps distinguish between different versions of the `gaia` CLI tool in Homebrew.

- Homebrew formula naming:
  * Changed the Homebrew formula name from `gaia` to `gaia@{{ .Version }}` to include the version number in the formula name.