### PR TITLE
fix: Adjust batch size and merge conditions for Dependabot PRs to dev queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ queue_rules:
   - name: dependabot-dev-queue
     autoqueue: true
     merge_method: rebase
+    update_method: rebase
     batch_size: 1
     merge_conditions:
       - -conflict


### PR DESCRIPTION
This commit modifies the .mergify.yml configuration file to adjust the batch size and merge conditions for Dependabot pull requests merging to the 'dev' branch.