### PR TITLE
fix: Add additional checks for lint and tests in pull requests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,6 +7,8 @@ queue_rules:
     batch_size: 1
     merge_conditions:
       - -conflict
+      - check-success~=(?i)lint
+      - check-success~=(?i)test
       - "#check-success >= 1"
 
 pull_request_rules:
@@ -14,8 +16,8 @@ pull_request_rules:
     conditions:
       - author = dependabot[bot]
       - base = dev
-      - check-success = lint
-      - check-success = test
+      - check-success~=(?i)lint
+      - check-success~=(?i)test
       - -draft
     actions:
       queue:


### PR DESCRIPTION
This commit adds two new rules to the `.mergify.yml` configuration file. The first rule, `check-success~=(?i)lint`, ensures that all lint checks pass before a pull request is merged. The second rule, `check-success~=(?i)test`, ensures that all tests pass before a pull request is merged. These additions aim to improve the quality of code changes by enforcing these checks during the pull request process.