### PR TITLE
feat: add support for local configuration overrides and trust management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # Go workspace file
 go.work
 gaia
+
+# Local configuration file
+.gaia.yaml

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ brew upgrade gaia
 
 Gaia stores its configuration in `~/.config/gaia/config.yaml`. The configuration file is automatically created on first run with sensible defaults.
 
+### Project-Local Overrides (`.gaia.yaml`)
+
+When you run Gaia inside a project, Gaia looks for a local `.gaia.yaml` (from your current directory up to the git repository root).
+
+- Local config is useful for project-specific `roles.*` prompts and `tools.*` actions.
+- On first detection, Gaia asks whether you trust that repository.
+- If trusted, local settings override your user config for that repository.
+- Trust decisions are stored in `~/.config/gaia/trusted-repos.yaml` and reused on next runs.
+- In non-interactive mode (CI, piped execution), untrusted local config is ignored and Gaia uses user/global config only.
+
+Configuration precedence is:
+
+`CLI flags > env vars > local .gaia.yaml > ~/.config/gaia/config.yaml > built-in defaults`
+
 ### Basic Configuration
 
 - `model`: The language model to use (default: "mistral" for Ollama, "gpt-4o-mini" for OpenAI, "mistral-medium-latest" for Mistral)
@@ -215,6 +229,21 @@ gaia config path
 
 # Create default configuration file
 gaia config create
+
+# Trust local project overrides for current repository
+gaia config trust
+
+# Remove trust for current repository
+gaia config untrust
+
+# Show trust status for current repository
+gaia config trust --status
+
+# List all trusted repositories
+gaia config trusted
+
+# Show trust status for a specific path/repository
+gaia config trusted /path/to/repo
 ```
 
 ### Using Different Roles

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -15,8 +16,8 @@ import (
 
 	"gaia/api"
 	"gaia/config"
+	"gaia/internal/termio"
 
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -222,6 +223,101 @@ var PathCmd = &cobra.Command{
 	},
 }
 
+var TrustCmd = &cobra.Command{
+	Use:   "trust [path]",
+	Short: "Trust local .gaia.yaml overrides for a repository",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := "."
+		if len(args) == 1 {
+			target = args[0]
+		}
+		repoRoot, err := config.ResolveRepositoryRootFromPath(target)
+		if err != nil {
+			return fmt.Errorf("resolve repository root from %q: %w", target, err)
+		}
+
+		statusOnly, _ := cmd.Flags().GetBool("status")
+		if statusOnly {
+			trusted, err := config.IsRepositoryTrusted(repoRoot)
+			if err != nil {
+				return fmt.Errorf("read trust status for %q: %w", repoRoot, err)
+			}
+			if trusted {
+				fmt.Printf("Trusted: yes (%s)\n", repoRoot)
+			} else {
+				fmt.Printf("Trusted: no (%s)\n", repoRoot)
+			}
+			return nil
+		}
+
+		if err := config.TrustRepository(repoRoot); err != nil {
+			return fmt.Errorf("trust repository %q: %w", repoRoot, err)
+		}
+		fmt.Printf("Trusted repository: %s\n", repoRoot)
+		fmt.Printf("Local overrides file (if present): %s\n", filepath.Join(repoRoot, ".gaia.yaml"))
+		return nil
+	},
+}
+
+var TrustedCmd = &cobra.Command{
+	Use:   "trusted [path]",
+	Short: "List trusted repositories or show trust status",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 {
+			repoRoot, err := config.ResolveRepositoryRootFromPath(args[0])
+			if err != nil {
+				return fmt.Errorf("resolve repository root from %q: %w", args[0], err)
+			}
+			trusted, err := config.IsRepositoryTrusted(repoRoot)
+			if err != nil {
+				return fmt.Errorf("read trust status for %q: %w", repoRoot, err)
+			}
+			if trusted {
+				fmt.Printf("Trusted: yes (%s)\n", repoRoot)
+			} else {
+				fmt.Printf("Trusted: no (%s)\n", repoRoot)
+			}
+			return nil
+		}
+
+		trustedRepos, err := config.ListTrustedRepositories()
+		if err != nil {
+			return fmt.Errorf("list trusted repositories: %w", err)
+		}
+		if len(trustedRepos) == 0 {
+			fmt.Println("No trusted repositories found")
+			return nil
+		}
+		for _, repo := range trustedRepos {
+			fmt.Println(repo)
+		}
+		return nil
+	},
+}
+
+var UntrustCmd = &cobra.Command{
+	Use:   "untrust [path]",
+	Short: "Remove trust for local .gaia.yaml overrides",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := "."
+		if len(args) == 1 {
+			target = args[0]
+		}
+		repoRoot, err := config.ResolveRepositoryRootFromPath(target)
+		if err != nil {
+			return fmt.Errorf("resolve repository root from %q: %w", target, err)
+		}
+		if err := config.UntrustRepository(repoRoot); err != nil {
+			return fmt.Errorf("untrust repository %q: %w", repoRoot, err)
+		}
+		fmt.Printf("Removed trust for repository: %s\n", repoRoot)
+		return nil
+	},
+}
+
 var AskCmd = &cobra.Command{
 	Use:   "ask [string]",
 	Short: "Ask to a model",
@@ -294,12 +390,7 @@ var ChatCmd = &cobra.Command{
 }
 
 func readStdin() string {
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		// If we can't stat stdin, assume it's not available and return empty
-		return ""
-	}
-	if (stat.Mode() & os.ModeCharDevice) == 0 {
+	if termio.HasPipedStdin() {
 		buf := make([]byte, 4096)
 		n, err := os.Stdin.Read(buf)
 		if err != nil && err != io.EOF {
@@ -322,6 +413,7 @@ func init() {
 		"Path to an alternative YAML configuration file (or $GAIA_CONFIG)",
 	)
 	ListCmd.Flags().BoolP("short", "s", false, "Truncate long values (e.g. role prompts) to 80 characters")
+	TrustCmd.Flags().Bool("status", false, "Show trust status instead of modifying it")
 }
 
 var buildCommandTreeOnce sync.Once
@@ -334,7 +426,7 @@ func BuildCommandTree() {
 }
 
 func buildCommandTree() {
-	ConfigCmd.AddCommand(ListCmd, SetCmd, GetCmd, PathCmd, CreateCmd)
+	ConfigCmd.AddCommand(ListCmd, SetCmd, GetCmd, PathCmd, CreateCmd, TrustCmd, UntrustCmd, TrustedCmd)
 	CacheCmd.AddCommand(CacheClearCmd, CacheStatsCmd, CacheListCmd, CacheDumpCmd)
 	AskCmd.Flags().StringP("role", "r", "", "Specify role code (default, describe, code)")
 	_ = viper.BindPFlag("systemrole", AskCmd.Flags().Lookup("role"))
@@ -492,7 +584,7 @@ func getToolActionConfig(tool, action string) (map[string]interface{}, error) {
 // promptForContext allows user to add or modify context.
 // Uses Bubble Tea TUI when stdout is a terminal, otherwise falls back to line-based input.
 func promptForContext(initialContext string) (string, error) {
-	if isatty.IsTerminal(os.Stdout.Fd()) {
+	if termio.HasTTYStdout() {
 		return runContextPromptTUI(initialContext)
 	}
 	reader := bufio.NewReader(os.Stdin)
@@ -544,7 +636,7 @@ func promptForContext(initialContext string) (string, error) {
 // promptForConfirmation asks user to confirm before executing.
 // Uses Bubble Tea TUI when stdout is a terminal, otherwise falls back to line-based input.
 func promptForConfirmation(message string) (bool, error) {
-	if isatty.IsTerminal(os.Stdout.Fd()) {
+	if termio.HasTTYStdout() {
 		return runConfirmationPromptTUI(message, "Confirm")
 	}
 	reader := bufio.NewReader(os.Stdin)

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -193,6 +193,83 @@ func TestConfigCmd_Path(t *testing.T) {
 	assert.Contains(t, string(out), "config.yaml")
 }
 
+func TestConfigCmd_TrustAndUntrust(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755))
+
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repoRoot))
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWd)
+	})
+
+	config.CfgFile = filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, config.InitConfig())
+
+	commands.RootCmd.SetArgs([]string{"config", "trust"})
+	err = commands.RootCmd.Execute()
+	require.NoError(t, err)
+
+	trusted, err := config.IsRepositoryTrusted(repoRoot)
+	require.NoError(t, err)
+	assert.True(t, trusted)
+
+	commands.RootCmd.SetArgs([]string{"config", "untrust"})
+	err = commands.RootCmd.Execute()
+	require.NoError(t, err)
+
+	trusted, err = config.IsRepositoryTrusted(repoRoot)
+	require.NoError(t, err)
+	assert.False(t, trusted)
+}
+
+func TestConfigCmd_TrustedAndTrustStatus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755))
+
+	config.CfgFile = filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, config.InitConfig())
+	require.NoError(t, config.TrustRepository(repoRoot))
+
+	resolvedRoot, err := config.ResolveRepositoryRootFromPath(repoRoot)
+	require.NoError(t, err)
+
+	captureRootOutput := func(args ...string) string {
+		oldStdout := os.Stdout
+		r, w, pipeErr := os.Pipe()
+		require.NoError(t, pipeErr)
+
+		os.Stdout = w
+		commands.RootCmd.SetArgs(args)
+		execErr := commands.RootCmd.Execute()
+
+		require.NoError(t, w.Close())
+		os.Stdout = oldStdout
+
+		out, readErr := io.ReadAll(r)
+		require.NoError(t, readErr)
+		require.NoError(t, r.Close())
+		require.NoError(t, execErr)
+		return string(out)
+	}
+
+	// config trusted (list)
+	out := captureRootOutput("config", "trusted")
+	assert.Contains(t, string(out), resolvedRoot)
+
+	// config trust --status
+	out2 := captureRootOutput("config", "trust", "--status", repoRoot)
+	assert.Contains(t, string(out2), "Trusted: yes")
+	assert.Contains(t, string(out2), resolvedRoot)
+}
+
 func TestCacheCmd_Stats(t *testing.T) {
 	tmpDir := t.TempDir()
 	config.CfgFile = filepath.Join(tmpDir, "config.yaml")

--- a/config/config.go
+++ b/config/config.go
@@ -165,14 +165,26 @@ func InitConfig() error {
 			if err := viper.SafeWriteConfigAs(CfgFile); err != nil {
 				var already viper.ConfigFileAlreadyExistsError
 				if errors.As(err, &already) || os.IsExist(err) {
-					return nil
+					if err := viper.ReadInConfig(); err != nil {
+						return fmt.Errorf("read config after create race: %w", err)
+					}
+				} else {
+					return fmt.Errorf("create default config: %w", err)
 				}
-				return fmt.Errorf("create default config: %w", err)
+			} else {
+				if err := viper.ReadInConfig(); err != nil {
+					return fmt.Errorf("read created default config: %w", err)
+				}
 			}
-			return nil
+		} else {
+			return fmt.Errorf("read config: %w", err)
 		}
-		return fmt.Errorf("read config: %w", err)
 	}
+
+	if err := loadTrustedLocalConfig(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"gaia/config"
@@ -12,7 +13,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func resetConfigState() {
+	viper.Reset()
+	config.CfgFile = ""
+}
+
 func TestInitConfig_CreatesFile(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 
@@ -31,6 +40,9 @@ func TestInitConfig_CreatesFile(t *testing.T) {
 }
 
 func TestInitConfig_UsesEnvVar(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	envFile := filepath.Join(dir, "config_env.yaml")
 	require.NoError(t, os.WriteFile(envFile, []byte{}, 0644))
@@ -50,6 +62,9 @@ func TestInitConfig_UsesEnvVar(t *testing.T) {
 }
 
 func TestSetConfigString_Success(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 
@@ -72,6 +87,9 @@ model: "mistral"
 }
 
 func TestSetConfigString_InvalidKey(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -82,6 +100,9 @@ func TestSetConfigString_InvalidKey(t *testing.T) {
 }
 
 func TestSetConfigString_AllValidKeys(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -104,9 +125,9 @@ func TestSetConfigString_AllValidKeys(t *testing.T) {
 
 func TestIsValidKey(t *testing.T) {
 	tests := []struct {
-		key      string
-		valid    bool
-		desc     string
+		key   string
+		valid bool
+		desc  string
 	}{
 		// Exact keys
 		{"model", true, "model"},
@@ -140,6 +161,9 @@ func TestIsValidKey(t *testing.T) {
 }
 
 func TestSetConfigString_NewKeysPersist(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -164,6 +188,9 @@ func TestSetConfigString_NewKeysPersist(t *testing.T) {
 }
 
 func TestSetConfigString_EmptyValue(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -175,9 +202,9 @@ func TestSetConfigString_EmptyValue(t *testing.T) {
 
 func TestIsListKey(t *testing.T) {
 	tests := []struct {
-		key   string
-		list  bool
-		desc  string
+		key  string
+		list bool
+		desc string
 	}{
 		{"operator.denylist", true, "operator.denylist"},
 		{"operator.allowlist", true, "operator.allowlist"},
@@ -196,6 +223,9 @@ func TestIsListKey(t *testing.T) {
 }
 
 func TestSetConfigString_ListKey_Success(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -207,6 +237,9 @@ func TestSetConfigString_ListKey_Success(t *testing.T) {
 }
 
 func TestSetConfigString_ListKey_RequiresJSON(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -217,6 +250,9 @@ func TestSetConfigString_ListKey_RequiresJSON(t *testing.T) {
 }
 
 func TestSetConfigString_ListKey_InvalidJSON(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -227,6 +263,9 @@ func TestSetConfigString_ListKey_InvalidJSON(t *testing.T) {
 }
 
 func TestSetConfigString_ListKey_AllowlistEmpty(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -238,6 +277,9 @@ func TestSetConfigString_ListKey_AllowlistEmpty(t *testing.T) {
 }
 
 func TestSetConfigString_WhitespaceValue(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 	require.NoError(t, config.InitConfig())
@@ -248,6 +290,9 @@ func TestSetConfigString_WhitespaceValue(t *testing.T) {
 }
 
 func TestInitConfig_CreatesDefaultValues(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 
@@ -282,6 +327,9 @@ func TestInitConfig_ExistingFilePreserved(t *testing.T) {
 }
 
 func TestInitConfig_InvalidYAML(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	config.CfgFile = filepath.Join(dir, "config.yaml")
 
@@ -294,6 +342,9 @@ func TestInitConfig_InvalidYAML(t *testing.T) {
 }
 
 func TestInitConfig_ReadOnlyFile(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	if os.Getuid() == 0 {
 		t.Skip("skipping test when running as root")
 	}
@@ -314,6 +365,9 @@ func TestInitConfig_ReadOnlyFile(t *testing.T) {
 }
 
 func TestInitConfig_NestedDirectoryCreation(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
 	dir := t.TempDir()
 	nestedPath := filepath.Join(dir, "nested", "deep")
 
@@ -325,4 +379,189 @@ func TestInitConfig_NestedDirectoryCreation(t *testing.T) {
 	err := config.InitConfig()
 	require.NoError(t, err)
 	require.FileExists(t, config.CfgFile)
+}
+
+func TestInitConfig_LocalConfigUntrusted_NonTTYIgnored(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".gaia.yaml"), []byte("model: local-model\nroles:\n  default: local-role\n"), 0644))
+
+	workDir := filepath.Join(repoRoot, "sub", "dir")
+	require.NoError(t, os.MkdirAll(workDir, 0755))
+
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWd)
+	})
+
+	config.CfgFile = filepath.Join(t.TempDir(), "global-config.yaml")
+	require.NoError(t, os.WriteFile(config.CfgFile, []byte("model: global-model\nroles:\n  default: global-role\n"), 0644))
+
+	require.NoError(t, config.InitConfig())
+	assert.Equal(t, "global-model", viper.GetString("model"))
+	assert.Equal(t, "global-role", viper.GetString("roles.default"))
+}
+
+func TestInitConfig_LocalConfigTrusted_Loaded(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".gaia.yaml"), []byte("model: local-model\nroles:\n  default: local-role\n"), 0644))
+
+	workDir := filepath.Join(repoRoot, "sub")
+	require.NoError(t, os.MkdirAll(workDir, 0755))
+
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWd)
+	})
+
+	require.NoError(t, config.TrustRepository(repoRoot))
+	trusted, err := config.IsRepositoryTrusted(repoRoot)
+	require.NoError(t, err)
+	assert.True(t, trusted)
+
+	config.CfgFile = filepath.Join(t.TempDir(), "global-config.yaml")
+	require.NoError(t, os.WriteFile(config.CfgFile, []byte("model: global-model\nroles:\n  default: global-role\n"), 0644))
+
+	require.NoError(t, config.InitConfig())
+	assert.Equal(t, "local-model", viper.GetString("model"))
+	assert.Equal(t, "local-role", viper.GetString("roles.default"))
+}
+
+func TestTrustAndUntrustRepository(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(repoRoot, 0755))
+
+	require.NoError(t, config.TrustRepository(repoRoot))
+	trusted, err := config.IsRepositoryTrusted(repoRoot)
+	require.NoError(t, err)
+	assert.True(t, trusted)
+
+	require.NoError(t, config.UntrustRepository(repoRoot))
+	trusted, err = config.IsRepositoryTrusted(repoRoot)
+	require.NoError(t, err)
+	assert.False(t, trusted)
+}
+
+func TestResolveRepositoryRootFromPath(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755))
+	nested := filepath.Join(repoRoot, "a", "b")
+	require.NoError(t, os.MkdirAll(nested, 0755))
+
+	resolved, err := config.ResolveRepositoryRootFromPath(nested)
+	require.NoError(t, err)
+	expectedRepoRoot, err := filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		expectedRepoRoot = repoRoot
+	}
+	assert.Equal(t, expectedRepoRoot, resolved)
+
+	nonRepo := filepath.Join(t.TempDir(), "norepo")
+	require.NoError(t, os.MkdirAll(nonRepo, 0755))
+	resolved, err = config.ResolveRepositoryRootFromPath(nonRepo)
+	require.NoError(t, err)
+	expectedNonRepo, err := filepath.EvalSymlinks(nonRepo)
+	if err != nil {
+		expectedNonRepo = nonRepo
+	}
+	assert.Equal(t, expectedNonRepo, resolved)
+}
+
+func TestListTrustedRepositories(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoA := filepath.Join(t.TempDir(), "repo-a")
+	repoB := filepath.Join(t.TempDir(), "repo-b")
+	require.NoError(t, os.MkdirAll(repoA, 0755))
+	require.NoError(t, os.MkdirAll(repoB, 0755))
+
+	require.NoError(t, config.TrustRepository(repoA))
+	require.NoError(t, config.TrustRepository(repoB))
+
+	trusted, err := config.ListTrustedRepositories()
+	require.NoError(t, err)
+
+	resolvedA, err := filepath.EvalSymlinks(repoA)
+	if err != nil {
+		resolvedA = repoA
+	}
+	resolvedB, err := filepath.EvalSymlinks(repoB)
+	if err != nil {
+		resolvedB = repoB
+	}
+
+	assert.Contains(t, trusted, resolvedA)
+	assert.Contains(t, trusted, resolvedB)
+}
+
+func TestTrustRepository_ConcurrentWrites(t *testing.T) {
+	resetConfigState()
+	defer resetConfigState()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const workers = 16
+	paths := make([]string, 0, workers)
+	for i := range workers {
+		repo := filepath.Join(t.TempDir(), "repo", string(rune('a'+i)))
+		require.NoError(t, os.MkdirAll(repo, 0755))
+		paths = append(paths, repo)
+	}
+
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for _, repo := range paths {
+		repo := repo
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- config.TrustRepository(repo)
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	trusted, err := config.ListTrustedRepositories()
+	require.NoError(t, err)
+	for _, repo := range paths {
+		resolved, evalErr := filepath.EvalSymlinks(repo)
+		if evalErr != nil {
+			resolved = repo
+		}
+		assert.Contains(t, trusted, resolved)
+	}
 }

--- a/config/trust.go
+++ b/config/trust.go
@@ -1,0 +1,358 @@
+package config
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gaia/internal/filelock"
+	"gaia/internal/pathutil"
+	"gaia/internal/termio"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	localConfigFileName = ".gaia.yaml"
+	trustStoreFileName  = "trusted-repos.yaml"
+	trustLockTimeout    = 5 * time.Second
+)
+
+func loadTrustedLocalConfig() error {
+	localConfigPath, repoRoot, found, err := discoverLocalConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to check local config: %v\n", err)
+		return nil
+	}
+	if !found {
+		return nil
+	}
+
+	trusted, err := IsRepositoryTrusted(repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to read trusted repositories: %v\n", err)
+		trusted = false
+	}
+
+	if !trusted {
+		if !termio.HasTTYStdin() || !termio.HasTTYStdout() {
+			fmt.Fprintf(os.Stderr, "Warning: ignored untrusted local config %s (run in a TTY to trust this repository)\n", localConfigPath)
+			return nil
+		}
+
+		allow, promptErr := promptTrustRepository(repoRoot, localConfigPath)
+		if promptErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to read trust confirmation: %v\n", promptErr)
+			return nil
+		}
+		if !allow {
+			fmt.Fprintf(os.Stderr, "Info: local config not trusted, using user/global config only\n")
+			return nil
+		}
+
+		if trustErr := TrustRepository(repoRoot); trustErr != nil {
+			return fmt.Errorf("trust repository: %w", trustErr)
+		}
+	}
+
+	if err := mergeLocalConfig(localConfigPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load local config %s: %v\n", localConfigPath, err)
+		return nil
+	}
+
+	return nil
+}
+
+func promptTrustRepository(repoRoot, localConfigPath string) (bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Fprintf(os.Stderr, "Detected local Gaia config at %s\n", localConfigPath)
+	fmt.Fprintf(os.Stderr, "Trust repository %s and load local overrides? [y/N]: ", repoRoot)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	input = strings.ToLower(strings.TrimSpace(input))
+	return input == "y" || input == "yes", nil
+}
+
+func mergeLocalConfig(localConfigPath string) error {
+	local := viper.New()
+	local.SetConfigFile(localConfigPath)
+	local.SetConfigType("yaml")
+	if err := local.ReadInConfig(); err != nil {
+		return err
+	}
+	return viper.MergeConfigMap(local.AllSettings())
+}
+
+// IsRepositoryTrusted returns whether the repository root is trusted for local .gaia.yaml overrides.
+func IsRepositoryTrusted(repoRoot string) (bool, error) {
+	normalized, err := pathutil.Normalize(repoRoot)
+	if err != nil {
+		return false, err
+	}
+
+	trusted := false
+	err = withTrustStoreReadLock(func(path string) error {
+		repos, err := readTrustedReposFromPath(path)
+		if err != nil {
+			return err
+		}
+		trusted = repos[normalized]
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return trusted, nil
+}
+
+// TrustRepository persists trust for the given repository root in the user trust store.
+func TrustRepository(repoRoot string) error {
+	normalized, err := pathutil.Normalize(repoRoot)
+	if err != nil {
+		return err
+	}
+
+	return withTrustStoreWriteLock(func(path string) error {
+		repos, err := readTrustedReposFromPath(path)
+		if err != nil {
+			return err
+		}
+		repos[normalized] = true
+		return writeTrustedReposToPath(path, repos)
+	})
+}
+
+// UntrustRepository removes trust for the given repository root.
+func UntrustRepository(repoRoot string) error {
+	normalized, err := pathutil.Normalize(repoRoot)
+	if err != nil {
+		return err
+	}
+
+	return withTrustStoreWriteLock(func(path string) error {
+		repos, err := readTrustedReposFromPath(path)
+		if err != nil {
+			return err
+		}
+		delete(repos, normalized)
+		return writeTrustedReposToPath(path, repos)
+	})
+}
+
+// ListTrustedRepositories returns all trusted repository roots.
+func ListTrustedRepositories() ([]string, error) {
+	trusted := []string{}
+	err := withTrustStoreReadLock(func(path string) error {
+		repos, err := readTrustedReposFromPath(path)
+		if err != nil {
+			return err
+		}
+		for root, ok := range repos {
+			if ok {
+				trusted = append(trusted, root)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(trusted)
+	return trusted, nil
+}
+
+// ResolveRepositoryRootFromPath resolves a repository root for trust operations.
+// If path is inside a git repository, it returns the git root.
+// Otherwise, it returns the normalized absolute directory path.
+func ResolveRepositoryRootFromPath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		path = "."
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	start := abs
+	if !info.IsDir() {
+		start = filepath.Dir(abs)
+	}
+	normalizedStart, err := pathutil.Normalize(start)
+	if err != nil {
+		return "", err
+	}
+	if gitRoot, ok, err := findGitRoot(normalizedStart); err == nil && ok {
+		return gitRoot, nil
+	}
+	return normalizedStart, nil
+}
+
+func discoverLocalConfig() (localConfigPath string, repoRoot string, found bool, err error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", false, err
+	}
+	cwd, err = pathutil.Normalize(cwd)
+	if err != nil {
+		return "", "", false, err
+	}
+
+	repoRoot = cwd
+	if gitRoot, ok, err := findGitRoot(cwd); err == nil && ok {
+		repoRoot = gitRoot
+	}
+
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, localConfigFileName)
+		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+			return candidate, repoRoot, true, nil
+		}
+		if dir == repoRoot {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", repoRoot, false, nil
+}
+
+func findGitRoot(start string) (string, bool, error) {
+	dir := start
+	for {
+		gitPath := filepath.Join(dir, ".git")
+		if _, err := os.Stat(gitPath); err == nil {
+			root, normErr := pathutil.Normalize(dir)
+			if normErr != nil {
+				return "", false, normErr
+			}
+			return root, true, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false, nil
+		}
+		dir = parent
+	}
+}
+
+func withTrustStoreReadLock(fn func(path string) error) error {
+	return withTrustStoreLock(filelock.Shared, fn)
+}
+
+func withTrustStoreWriteLock(fn func(path string) error) error {
+	return withTrustStoreLock(filelock.Exclusive, fn)
+}
+
+func withTrustStoreLock(mode filelock.Mode, fn func(path string) error) error {
+	storePath, err := trustStorePath()
+	if err != nil {
+		return err
+	}
+	lockPath := storePath + ".lock"
+	if err := filelock.With(lockPath, mode, trustLockTimeout, func() error {
+		return fn(storePath)
+	}); err != nil {
+		return fmt.Errorf("lock trust store: %w", err)
+	}
+	return nil
+}
+
+func readTrustedReposFromPath(path string) (map[string]bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, fs.ErrNotExist) {
+			return map[string]bool{}, nil
+		}
+		return nil, fmt.Errorf("read trusted repos: %w", err)
+	}
+
+	var payload struct {
+		TrustedRepos map[string]bool `yaml:"trusted_repos"`
+	}
+	if err := yaml.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("decode trusted repos: %w", err)
+	}
+
+	repos := make(map[string]bool, len(payload.TrustedRepos))
+	for key, isTrusted := range payload.TrustedRepos {
+		normalized, normErr := pathutil.Normalize(key)
+		if normErr != nil {
+			continue
+		}
+		repos[normalized] = isTrusted
+	}
+	return repos, nil
+}
+
+func writeTrustedReposToPath(path string, repos map[string]bool) error {
+	payload := struct {
+		TrustedRepos map[string]bool `yaml:"trusted_repos"`
+	}{
+		TrustedRepos: repos,
+	}
+
+	data, err := yaml.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode trusted repos: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	tmpFile, err := os.CreateTemp(dir, "trusted-repos-*.yaml")
+	if err != nil {
+		return fmt.Errorf("create temp trusted repo file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	writeErr := error(nil)
+	if _, err := tmpFile.Write(data); err != nil {
+		writeErr = fmt.Errorf("write temp trusted repo file: %w", err)
+	}
+	if err := tmpFile.Chmod(0o600); err != nil && writeErr == nil {
+		writeErr = fmt.Errorf("chmod temp trusted repo file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil && writeErr == nil {
+		writeErr = fmt.Errorf("close temp trusted repo file: %w", err)
+	}
+	if writeErr != nil {
+		_ = os.Remove(tmpPath)
+		return writeErr
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace trusted repo file: %w", err)
+	}
+
+	return nil
+}
+
+func trustStorePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine home directory: %w", err)
+	}
+	configDir := filepath.Join(homeDir, ".config", "gaia")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create config directory %s: %w", configDir, err)
+	}
+	return filepath.Join(configDir, trustStoreFileName), nil
+}

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,65 @@
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+type Mode int
+
+const (
+	Shared Mode = iota
+	Exclusive
+)
+
+const retryInterval = 25 * time.Millisecond
+
+// With acquires a lock on lockPath, executes fn, then releases the lock.
+// If timeout is <= 0, it attempts lock acquisition only once.
+func With(lockPath string, mode Mode, timeout time.Duration, fn func() error) error {
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open lock file %s: %w", lockPath, err)
+	}
+	defer func() {
+		_ = lockFile.Close()
+	}()
+
+	if err := acquire(lockFile, mode, timeout); err != nil {
+		return err
+	}
+	defer func() {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	}()
+
+	return fn()
+}
+
+func acquire(lockFile *os.File, mode Mode, timeout time.Duration) error {
+	lockType := syscall.LOCK_SH
+	if mode == Exclusive {
+		lockType = syscall.LOCK_EX
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		err := syscall.Flock(int(lockFile.Fd()), lockType|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			return fmt.Errorf("acquire file lock: %w", err)
+		}
+
+		if timeout <= 0 || time.Now().After(deadline) {
+			return fmt.Errorf("timed out acquiring file lock after %s", timeout)
+		}
+		time.Sleep(retryInterval)
+	}
+}

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,25 @@
+package pathutil
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Normalize resolves to an absolute, cleaned path and resolves symlinks when possible.
+// If the path does not exist yet, it still returns a clean absolute path.
+func Normalize(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err == nil {
+		return filepath.Clean(resolved), nil
+	}
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, fs.ErrNotExist) {
+		return filepath.Clean(abs), nil
+	}
+	return "", err
+}

--- a/internal/termio/termio.go
+++ b/internal/termio/termio.go
@@ -1,0 +1,28 @@
+package termio
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// HasTTYStdin reports whether stdin is connected to a terminal.
+func HasTTYStdin() bool {
+	fd := os.Stdin.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+// HasTTYStdout reports whether stdout is connected to a terminal.
+func HasTTYStdout() bool {
+	fd := os.Stdout.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+// HasPipedStdin reports whether stdin carries piped or redirected input.
+func HasPipedStdin() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}

--- a/internal/termio/termio_test.go
+++ b/internal/termio/termio_test.go
@@ -1,0 +1,9 @@
+package termio
+
+import "testing"
+
+func TestHasTTYHelpers_NoPanic(t *testing.T) {
+	_ = HasTTYStdin()
+	_ = HasTTYStdout()
+	_ = HasPipedStdin()
+}


### PR DESCRIPTION
This update introduces a new feature allowing users to define project-specific configurations using a `.gaia.yaml` file. When running Gaia within a project, it checks for this local configuration file and prompts the user to trust it. If trusted, local settings will override global configurations.

Additionally, commands for managing trust status have been added:
- `gaia config trust` to trust a repository.
- `gaia config untrust` to remove trust.
- `gaia config trusted` to list trusted repositories or check trust status.

The README has been updated to reflect these changes, providing guidance on using local overrides and trust management effectively.